### PR TITLE
Update projects

### DIFF
--- a/EDITME.html
+++ b/EDITME.html
@@ -6,11 +6,11 @@ Enter <strong>Content Providers</strong>, Android's way for apps to provide stru
 
 <h3>Getting started</h3>
 
-You'll need two sample apps to demonstrate the capabilities of Content Providers. The first app, <strong>Planet Provider</strong>, wraps around a SQLite database of moons and planets, and the latitudes and longitudes of rebel bases on those moons and planets.
+We'll need two sample apps to demonstrate the capabilities of Content Providers. The first app, <strong>Planet Provider</strong>, wraps around a SQLite database of moons and planets, and the latitudes and longitudes of rebel bases on those moons and planets.
 
-Download the Planet Provider starter app and run the app on an emulator. Open the Android Monitor in Android Studio in order to read the log outputs and filter for the string <code>test</code>.
+Download the Planet Provider starter app and run the app on an emulator. Go to the Logcat tab in Android Studio in order to read the log outputs and filter for the string <code>test</code>.
 
-When the app opens, you can read in the logs that the app is reading the included SQLite database and printing the contents. Currently that data is only readable inside the PlanetProver app, so next you'll add a Content Provider to export the information.
+When the app opens, we can read in the logs that the app is reading the included SQLite database and printing the contents. Currently that data is only readable inside the PlanetProver app, so next we'll add a Content Provider to export the information.
 
 <h2>Creating the Content provider</h2>
 
@@ -49,7 +49,7 @@ lateinit private var db: SQLiteDatabase
 Then, tell the DBHelper to get your readable SQLite database, and query for the ID numbers and names of planets in the database:
 
 <pre lang="kotlin">
-  override fun query(uri: Uri, projection: Array<String>, selection: String?, selectionArgs: Array<String>, sortOrder: String): Cursor {
+  override fun query(uri: Uri, projection: Array<String>, selection: String?, selectionArgs: Array<String>, sortOrder: String?): Cursor {
     this.db = dbHelper.readableDatabase
     if (selection != null) {
       return this.db.rawQuery("select id as _id, name from planets where " + selection, arrayOf<String>())
@@ -118,7 +118,8 @@ private fun refresh_name_table() {
       android.R.layout.simple_list_item_1,
       cursor,
       arrayOf("name"),
-      intArrayOf(android.R.id.text1)
+      intArrayOf(android.R.id.text1),
+      0
     )
   }
 }
@@ -126,7 +127,7 @@ private fun refresh_name_table() {
 
 First, you create and send a query at the specified URI, and assign the results to a Cursor. If the cursor is not null, then you use the handy <code>SimpleCursorAdapter</code> to
 
-<img src="https://www.raywenderlich.com/wp-content/uploads/2016/05/Screenshot_20160510-132658.png" alt="Screenshot_20160510-132658" width="1080" height="1920" class="aligncenter size-full wp-image-134006" />
+<img src="https://koenig-media.raywenderlich.com/uploads/2021/05/Screenshot_1621316967.png" alt="Screenshot_1621316967" width="1080" height="1920" class="aligncenter size-full wp-image-134006" />
 
 <h2>Locating the rebel bases</h2>
 
@@ -134,7 +135,7 @@ As your provider is set up now, it is actually possible for your consumer app to
 
 While the consumer can't query for the base locations directly, what it <em>can</em> do is sneak guesses at the base location into the WHERE clause of normal queries, over and over until it finds the right answer.
 
-In PlanetConsumer's MainActivity, take a look at the method <code>hackToFindRebelBaseWithQuery()</code>. Inside are two searches: one for the base latitude and one for the base longitude. After the searches are finished, they display a Toast on the phone and log to the Android Monitor the location of the rebel base on a certain planet or moon.
+In PlanetConsumer's MainActivity, take a look at the method <code>hackToFindRebelBaseWithQuery()</code>. Inside are two searches: one for the base latitude and one for the base longitude. After the searches are finished, they display a Toast on the phone and enter a Logcat log with the location of the rebel base on a certain planet or moon.
 
 To try it out, find the <code>// TODO</code> inside the <code>onClick()</code> method connected to the Button. Replace the <code>// TODO</code> with a call to <code>hackToFindRebelBaseWithQuery()</code>
 
@@ -144,7 +145,7 @@ button.setOnClickListener(View.OnClickListener {
 })
 </pre>
 
-<img src="https://www.raywenderlich.com/wp-content/uploads/2016/05/Screenshot_20160510-134754-281x500.png" alt="Screenshot_20160510-134754" width="281" height="500" class="aligncenter size-large wp-image-134008" />
+<img src="https://koenig-media.raywenderlich.com/uploads/2021/05/Screenshot_1621317087.png" alt="Screenshot_1621317087" width="281" height="500" class="aligncenter size-large wp-image-134008" />
 
 <h2>Manifest Permissions</h2>
 
@@ -168,7 +169,7 @@ It's not required, but a good practice to include the namespace for your app in 
 
 The permission you just added allows both reading and writing with your content provider. Without it, interactions with the provider are blocked.
 
-To see this in action, Build and Run PlanetProvider to load an APK with the updated Manifest to your device. Then, Build and Run PlanetConsumer. Your app will crash as soon as it tries to read the planet names, and a check of the Android Monitor gives the message:
+To see this in action, Build and Run PlanetProvider to load an APK with the updated Manifest to your device. Then, Build and Run PlanetConsumer. Your app will crash as soon as it tries to read the planet names, and a check in the Logcat tab gives the message:
 
 <pre lang="java">
 java.lang.SecurityException: Permission Denial: opening provider com.razeware.planetprovider.PlanetContentProvider from ... requires com.razeware.planetprovider.NAMES or com.razeware.planetprovider.NAMES
@@ -338,7 +339,8 @@ private fun refresh_name_table() {
         android.R.layout.simple_list_item_1,
         cursor,
         arrayOf("name"),
-        intArrayOf(android.R.id.text1)
+        intArrayOf(android.R.id.text1),
+        0
     )
   }
 }

--- a/planetconsumer-final/app/build.gradle
+++ b/planetconsumer-final/app/build.gradle
@@ -2,17 +2,15 @@ apply plugin: 'com.android.application'
 
 apply plugin: 'kotlin-android'
 
-apply plugin: 'kotlin-android-extensions'
-
 android {
-    compileSdkVersion 28
+    compileSdkVersion 30
     defaultConfig {
         applicationId "com.razeware.planetconsumer"
         minSdkVersion 19
-        targetSdkVersion 28
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
     buildTypes {
         release {
@@ -25,9 +23,9 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.android.support:appcompat-v7:28.0.0-rc01'
-    implementation 'com.android.support.constraint:constraint-layout:1.1.2'
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
+    testImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
 }

--- a/planetconsumer-final/app/src/androidTest/java/com/razeware/planetconsumer/ExampleInstrumentedTest.kt
+++ b/planetconsumer-final/app/src/androidTest/java/com/razeware/planetconsumer/ExampleInstrumentedTest.kt
@@ -1,7 +1,7 @@
 package com.razeware.planetconsumer
 
-import android.support.test.InstrumentationRegistry
-import android.support.test.runner.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.ext.junit.runners.AndroidJUnit4
 
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -18,7 +18,7 @@ class ExampleInstrumentedTest {
   @Test
   fun useAppContext() {
     // Context of the app under test.
-    val appContext = InstrumentationRegistry.getTargetContext()
+    val appContext = InstrumentationRegistry.getInstrumentation().targetContext
     assertEquals("com.razeware.planetconsumer", appContext.packageName)
   }
 }

--- a/planetconsumer-final/app/src/main/AndroidManifest.xml
+++ b/planetconsumer-final/app/src/main/AndroidManifest.xml
@@ -2,6 +2,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="com.razeware.planetconsumer">
 
+  <queries>
+    <package android:name="com.razeware.planetprovider" />
+  </queries>
+
   <permission android:name="com.razeware.planetprovider.READ_NAMES"/>
   <uses-permission android:name="com.razeware.planetprovider.READ_NAMES"/>
   <uses-permission-sdk-23 android:name="com.razeware.planetprovider.READ_NAMES"/>

--- a/planetconsumer-final/app/src/main/java/com/razeware/planetconsumer/MainActivity.kt
+++ b/planetconsumer-final/app/src/main/java/com/razeware/planetconsumer/MainActivity.kt
@@ -4,7 +4,7 @@ import android.content.ContentValues
 import android.database.Cursor
 import android.net.Uri
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatActivity
 import android.util.Log
 import android.view.View
 import android.widget.Button
@@ -50,7 +50,8 @@ class MainActivity : AppCompatActivity() {
           android.R.layout.simple_list_item_1,
           cursor,
           arrayOf("name"),
-          intArrayOf(android.R.id.text1)
+          intArrayOf(android.R.id.text1),
+          0
       )
     }
   }
@@ -67,7 +68,8 @@ class MainActivity : AppCompatActivity() {
         android.R.layout.simple_list_item_2,
         cursor,
         arrayOf("rebel_base_lat", "rebel_base_lng"),
-        intArrayOf(android.R.id.text1, android.R.id.text2)
+        intArrayOf(android.R.id.text1, android.R.id.text2),
+        0
     )
   }
 

--- a/planetconsumer-final/build.gradle
+++ b/planetconsumer-final/build.gradle
@@ -1,13 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.2.61'
+    ext.kotlin_version = '1.5.0'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:4.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong
@@ -18,7 +18,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/planetconsumer-final/gradle.properties
+++ b/planetconsumer-final/gradle.properties
@@ -9,6 +9,8 @@
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
+android.enableJetifier=true
+android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536m
 
 # When configured, Gradle will run in incubating parallel mode.

--- a/planetconsumer-final/gradle/wrapper/gradle-wrapper.properties
+++ b/planetconsumer-final/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Aug 24 15:38:30 EDT 2018
+#Mon May 17 17:55:20 PDT 2021
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+zipStoreBase=GRADLE_USER_HOME

--- a/planetconsumer-starter/app/build.gradle
+++ b/planetconsumer-starter/app/build.gradle
@@ -2,17 +2,15 @@ apply plugin: 'com.android.application'
 
 apply plugin: 'kotlin-android'
 
-apply plugin: 'kotlin-android-extensions'
-
 android {
-    compileSdkVersion 28
+    compileSdkVersion 30
     defaultConfig {
         applicationId "com.razeware.planetconsumer"
         minSdkVersion 19
-        targetSdkVersion 28
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
     buildTypes {
         release {
@@ -25,9 +23,9 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.android.support:appcompat-v7:28.0.0-rc01'
-    implementation 'com.android.support.constraint:constraint-layout:1.1.2'
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
+    testImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
 }

--- a/planetconsumer-starter/app/src/androidTest/java/com/razeware/planetconsumer/ExampleInstrumentedTest.kt
+++ b/planetconsumer-starter/app/src/androidTest/java/com/razeware/planetconsumer/ExampleInstrumentedTest.kt
@@ -1,7 +1,7 @@
 package com.razeware.planetconsumer
 
-import android.support.test.InstrumentationRegistry
-import android.support.test.runner.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.ext.junit.runners.AndroidJUnit4
 
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -18,7 +18,7 @@ class ExampleInstrumentedTest {
   @Test
   fun useAppContext() {
     // Context of the app under test.
-    val appContext = InstrumentationRegistry.getTargetContext()
+    val appContext = InstrumentationRegistry.getInstrumentation().targetContext
     assertEquals("com.razeware.planetconsumer", appContext.packageName)
   }
 }

--- a/planetconsumer-starter/app/src/main/java/com/razeware/planetconsumer/MainActivity.kt
+++ b/planetconsumer-starter/app/src/main/java/com/razeware/planetconsumer/MainActivity.kt
@@ -4,7 +4,7 @@ import android.content.ContentValues
 import android.database.Cursor
 import android.net.Uri
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatActivity
 import android.util.Log
 import android.view.View
 import android.widget.Button
@@ -12,6 +12,8 @@ import android.widget.EditText
 import android.widget.ListView
 import android.widget.SimpleCursorAdapter
 import android.widget.Toast
+import androidx.loader.app.LoaderManager
+import androidx.loader.content.CursorLoader
 
 import java.text.DecimalFormat
 
@@ -55,7 +57,8 @@ class MainActivity : AppCompatActivity() {
         android.R.layout.simple_list_item_2,
         cursor,
         arrayOf("rebel_base_lat", "rebel_base_lng"),
-        intArrayOf(android.R.id.text1, android.R.id.text2)
+        intArrayOf(android.R.id.text1, android.R.id.text2),
+        0
     )
   }
 

--- a/planetconsumer-starter/build.gradle
+++ b/planetconsumer-starter/build.gradle
@@ -1,13 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.2.61'
+    ext.kotlin_version = '1.5.0'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:4.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong
@@ -18,7 +18,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/planetconsumer-starter/gradle.properties
+++ b/planetconsumer-starter/gradle.properties
@@ -9,6 +9,8 @@
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
+android.enableJetifier=true
+android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536m
 
 # When configured, Gradle will run in incubating parallel mode.

--- a/planetconsumer-starter/gradle/wrapper/gradle-wrapper.properties
+++ b/planetconsumer-starter/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Aug 24 15:38:30 EDT 2018
+#Mon May 17 17:55:20 PDT 2021
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+zipStoreBase=GRADLE_USER_HOME

--- a/planetprovider-final/app/build.gradle
+++ b/planetprovider-final/app/build.gradle
@@ -2,8 +2,6 @@ apply plugin: 'com.android.application'
 
 apply plugin: 'kotlin-android'
 
-apply plugin: 'kotlin-android-extensions'
-
 android {
     compileSdkVersion 28
     defaultConfig {
@@ -12,7 +10,7 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
     buildTypes {
         release {
@@ -25,12 +23,12 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.android.support:appcompat-v7:28.0.0-rc01'
-    implementation 'com.android.support.constraint:constraint-layout:1.1.2'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
 
     implementation 'com.readystatesoftware.sqliteasset:sqliteassethelper:2.0.1'
 
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    testImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
 }

--- a/planetprovider-final/app/src/androidTest/java/com/razeware/planetprovider/ExampleInstrumentedTest.kt
+++ b/planetprovider-final/app/src/androidTest/java/com/razeware/planetprovider/ExampleInstrumentedTest.kt
@@ -1,7 +1,7 @@
 package com.razeware.planetprovider
 
-import android.support.test.InstrumentationRegistry
-import android.support.test.runner.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.ext.junit.runners.AndroidJUnit4
 
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -18,7 +18,7 @@ class ExampleInstrumentedTest {
   @Test
   fun useAppContext() {
     // Context of the app under test.
-    val appContext = InstrumentationRegistry.getTargetContext()
+    val appContext = InstrumentationRegistry.getInstrumentation().targetContext
     assertEquals("com.razeware.planetprovider", appContext.packageName)
   }
 }

--- a/planetprovider-final/app/src/main/java/com/razeware/planetprovider/MainActivity.kt
+++ b/planetprovider-final/app/src/main/java/com/razeware/planetprovider/MainActivity.kt
@@ -1,6 +1,6 @@
 package com.razeware.planetprovider
 
-import android.support.v7.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.util.Log
 

--- a/planetprovider-final/app/src/main/java/com/razeware/planetprovider/PlanetContentProvider.kt
+++ b/planetprovider-final/app/src/main/java/com/razeware/planetprovider/PlanetContentProvider.kt
@@ -6,8 +6,7 @@ import android.database.Cursor
 import android.net.Uri
 import android.database.sqlite.SQLiteDatabase
 import android.content.UriMatcher
-
-
+import androidx.core.content.ContentProviderCompat
 
 
 class PlanetContentProvider : ContentProvider() {
@@ -31,7 +30,7 @@ class PlanetContentProvider : ContentProvider() {
   lateinit private var dbHelper: DBHelper
   lateinit private var db: SQLiteDatabase
 
-  override fun insert(p0: Uri?, p1: ContentValues?): Uri {
+  override fun insert(p0: Uri, p1: ContentValues?): Uri? {
     TODO("not implemented")
   }
 
@@ -47,19 +46,19 @@ class PlanetContentProvider : ContentProvider() {
   }
 
   override fun onCreate(): Boolean {
-    this.dbHelper = DBHelper(context)
+    this.dbHelper = DBHelper(ContentProviderCompat.requireContext(this))
     return true
   }
 
-  override fun update(p0: Uri?, p1: ContentValues?, p2: String?, p3: Array<out String>?): Int {
+  override fun update(p0: Uri, p1: ContentValues?, p2: String?, p3: Array<out String>?): Int {
     TODO("not implemented")
   }
 
-  override fun delete(p0: Uri?, p1: String?, p2: Array<out String>?): Int {
+  override fun delete(p0: Uri, p1: String?, p2: Array<out String>?): Int {
     TODO("not implemented")
   }
 
-  override fun getType(p0: Uri?): String {
+  override fun getType(p0: Uri): String {
     TODO("not implemented")
   }
 }

--- a/planetprovider-final/app/src/main/res/layout/activity_main.xml
+++ b/planetprovider-final/app/src/main/res/layout/activity_main.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
@@ -15,4 +15,4 @@
     app:layout_constraintRight_toRightOf="parent"
     app:layout_constraintTop_toTopOf="parent" />
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/planetprovider-final/build.gradle
+++ b/planetprovider-final/build.gradle
@@ -1,13 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.2.61'
+    ext.kotlin_version = '1.5.0'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:4.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong
@@ -18,7 +18,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/planetprovider-final/gradle.properties
+++ b/planetprovider-final/gradle.properties
@@ -9,6 +9,8 @@
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
+android.enableJetifier=true
+android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536m
 
 # When configured, Gradle will run in incubating parallel mode.

--- a/planetprovider-final/gradle/wrapper/gradle-wrapper.properties
+++ b/planetprovider-final/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Aug 24 15:33:29 EDT 2018
+#Mon May 17 17:55:20 PDT 2021
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+zipStoreBase=GRADLE_USER_HOME

--- a/planetprovider-starter/app/build.gradle
+++ b/planetprovider-starter/app/build.gradle
@@ -2,17 +2,15 @@ apply plugin: 'com.android.application'
 
 apply plugin: 'kotlin-android'
 
-apply plugin: 'kotlin-android-extensions'
-
 android {
-    compileSdkVersion 28
+    compileSdkVersion 30
     defaultConfig {
         applicationId "com.razeware.planetprovider"
         minSdkVersion 19
-        targetSdkVersion 28
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
     buildTypes {
         release {
@@ -25,12 +23,12 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.android.support:appcompat-v7:28.0.0-rc01'
-    implementation 'com.android.support.constraint:constraint-layout:1.1.2'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
 
     implementation 'com.readystatesoftware.sqliteasset:sqliteassethelper:2.0.1'
 
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    testImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
 }

--- a/planetprovider-starter/app/src/androidTest/java/com/razeware/planetprovider/ExampleInstrumentedTest.kt
+++ b/planetprovider-starter/app/src/androidTest/java/com/razeware/planetprovider/ExampleInstrumentedTest.kt
@@ -1,7 +1,8 @@
 package com.razeware.planetprovider
 
-import android.support.test.InstrumentationRegistry
-import android.support.test.runner.AndroidJUnit4
+import androidx.test.InstrumentationRegistry.getTargetContext
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.ext.junit.runners.AndroidJUnit4
 
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -18,7 +19,7 @@ class ExampleInstrumentedTest {
   @Test
   fun useAppContext() {
     // Context of the app under test.
-    val appContext = InstrumentationRegistry.getTargetContext()
+    val appContext = InstrumentationRegistry.getInstrumentation().targetContext
     assertEquals("com.razeware.planetprovider", appContext.packageName)
   }
 }

--- a/planetprovider-starter/app/src/main/AndroidManifest.xml
+++ b/planetprovider-starter/app/src/main/AndroidManifest.xml
@@ -2,6 +2,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="com.razeware.planetprovider">
 
+  <queries>
+    <package android:name="com.razeware.planetprovider" />
+  </queries>
+
   <application
     android:allowBackup="true"
     android:icon="@mipmap/ic_launcher"

--- a/planetprovider-starter/app/src/main/java/com/razeware/planetprovider/MainActivity.kt
+++ b/planetprovider-starter/app/src/main/java/com/razeware/planetprovider/MainActivity.kt
@@ -1,6 +1,6 @@
 package com.razeware.planetprovider
 
-import android.support.v7.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.util.Log
 

--- a/planetprovider-starter/app/src/main/res/layout/activity_main.xml
+++ b/planetprovider-starter/app/src/main/res/layout/activity_main.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
@@ -15,4 +15,4 @@
     app:layout_constraintRight_toRightOf="parent"
     app:layout_constraintTop_toTopOf="parent" />
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/planetprovider-starter/build.gradle
+++ b/planetprovider-starter/build.gradle
@@ -1,13 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.2.61'
+    ext.kotlin_version = '1.5.0'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:4.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong
@@ -18,7 +18,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/planetprovider-starter/gradle.properties
+++ b/planetprovider-starter/gradle.properties
@@ -9,6 +9,8 @@
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
+android.enableJetifier=true
+android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536m
 
 # When configured, Gradle will run in incubating parallel mode.

--- a/planetprovider-starter/gradle/wrapper/gradle-wrapper.properties
+++ b/planetprovider-starter/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Aug 24 15:33:29 EDT 2018
+#Mon May 17 17:55:20 PDT 2021
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
- Kotlin & Gradle versions updated to the latest
- Migrated to AndroidX
- Kotlin Extensions plugin removed now that the projects are using AndroidX
- jcenter repo is deprecated; switched over to mavenCentral in the **build.gradle** `repositories { }` blocks.
- Bumped compile and target SDKs to 30
- Added `<queries>` tag to support access to PlanetProvider's ContentProvider in API 30+